### PR TITLE
fix: Bug do scroll voltando ao topo ao atualizar a página

### DIFF
--- a/src/components/bible-reader/reader.tsx
+++ b/src/components/bible-reader/reader.tsx
@@ -20,7 +20,7 @@ interface HighlightedVerse {
 }
 
 export function BibleReader({ book, chapter, verses }: BibleReaderProps) {
-    window.scrollTo({ top: 0, behavior: "instant" });
+    useEffect(() => window.scrollTo({ top: 0, behavior: "instant" }), []);
 
     const { settings } = useSettings();
     const { fontSize } = settings;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client'
 import './index.css'
 
@@ -7,8 +6,8 @@ import { Toaster } from '@/components/ui/toaster'
 import App from '@/App.tsx'
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
+  <>
     <Toaster />
     <App />
-  </StrictMode>
+  </>
 )

--- a/src/pages/books.tsx
+++ b/src/pages/books.tsx
@@ -20,7 +20,6 @@ const SkeletonBooks = (props: { width: number }) => (
 );
 
 export default function Books() {
-    window.scrollTo({ top: 0, behavior: "instant" });
 
     const navigate = useNavigate();
     const [searchParams, _] = useSearchParams();
@@ -43,6 +42,8 @@ export default function Books() {
     };
 
     useEffect(() => {
+        window.scrollTo({ top: 0, behavior: "instant" });
+
         document.title = 'Biblify | Livros';
 
         (async () => {
@@ -62,7 +63,7 @@ export default function Books() {
 
     return (
         <div className="animate-opacity bg-primary-foreground min-h-screen">
-            <header className="flex flex-col gap-6 w-full bg-primary-foreground border-b-[1px] p-4 fixed top-0 transition-all duration-200 ease-in h-20">
+            <header className="flex flex-col gap-6 w-full bg-primary-foreground border-b-[1px] p-4 fixed top-0 transition-all duration-200 ease-in h-20 z-10">
                 <div className="w-full flex justify-around items-center ">
                     <Link className="group w-4/8" to={`/${version ?? 'nvi'}/${abbrev ?? 'gn'}/${chapter ?? '1'}`}>
                         <Button className="bg-primary-foreground border border-b-2 border-primary text-primary hover:text-primary-foreground hover:bg-primary">

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -15,11 +15,11 @@ interface Verse {
 }
 
 export default function Home() {
-    window.scrollTo({ top: 0, behavior: "instant" });
-
     const [verseOfDay, setVerseOfDay] = useState<Verse | null>(null);
 
     useEffect(() => {
+        window.scrollTo({ top: 0, behavior: "instant" });
+
         const date = new Date().getDate();
         setVerseOfDay(getVerseOfDay(date));
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -26,8 +26,6 @@ const familyFonts = [
 ]
 
 export default function Settings() {
-    window.scrollTo({ top: 0, behavior: "instant" });
-
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     const target = searchParams.get('_target') ?? '';
@@ -40,6 +38,8 @@ export default function Settings() {
     }
 
     useEffect(() => {
+        window.scrollTo({ top: 0, behavior: "instant" });
+
         document.title = 'Biblify | Ajustes';
     }, []);
 

--- a/src/pages/versions.tsx
+++ b/src/pages/versions.tsx
@@ -31,8 +31,6 @@ const SkeletonRadioGroup = () => (
 )
 
 export default function Versions() {
-    window.scrollTo({ top: 0, behavior: "instant" });
-
     const navigate = useNavigate();
     const [searchParams, _] = useSearchParams();
     const target = searchParams.get('_target');
@@ -45,6 +43,8 @@ export default function Versions() {
     }
 
     useEffect(() => {
+        window.scrollTo({ top: 0, behavior: "instant" });
+
         document.title = 'Biblify | Versões';
 
         (async () => {


### PR DESCRIPTION
O problema atrapalhada na UX e foi identificado pelo usuário `Landowski` no TabNews: 
> Notei algo: quando eu clico no card (accordion) para abrir Apocalipse, ele volta lá no início da página em vez de manter e abrir ali mesmo. [...]
> Fonte: [Em resposta a '*Biblify: Meu projeto de leitor da Bíblia*'](https://www.tabnews.com.br/Landowski/454803c7-0f02-46cc-a41c-aebd26b10763)
>

Removendo o `StrictMode`e colocando o `window.scrollTop()` em um `useEffect`sem depêndencias o problema já foi resolvido.