### PR TITLE
Fix: Erro ao inserir devocional

### DIFF
--- a/api/src/models/devotional-notation.ts
+++ b/api/src/models/devotional-notation.ts
@@ -2,10 +2,12 @@ import { Schema, model } from 'mongoose';
 import IDevotionalNotation from '../interfaces/devotional-notation';
 
 const devotionalNotationsSchema = new Schema<IDevotionalNotation>({
-    userId: { type: String, required: true, unique: true },
+    userId: { type: String, required: true },
     date: { type: Date, required: true },
     content: { type: String, required: true }
 });
+
+devotionalNotationsSchema.index({ userId: 1, date: 1 }, { unique: true });
 
 const DevotionalNotations = model<IDevotionalNotation>('DevotionalNotations', devotionalNotationsSchema);
 


### PR DESCRIPTION
> - Se um usuário tivesse uma anotação ele apontava erro de duplicidade de chave única. O modelo dos devocionais coloca o userId como uma chave única. Para corrigir criei uma chave única composta que permite que o usuário tenha apenas um registro com mesmo userId e date.
![image](https://github.com/user-attachments/assets/caca8687-e551-4081-8ff2-c6113693da11)
